### PR TITLE
srt: release e_poll not longer used

### DIFF
--- a/ext/srt/gstsrtobject.c
+++ b/ext/srt/gstsrtobject.c
@@ -1021,7 +1021,9 @@ gst_srt_object_open_full (GstSRTObject * srtobject,
     connection_mode = GST_TYPE_SRT_CONNECTION_MODE;
   }
 
-  srtobject->listener_poll_id = srt_epoll_create ();
+  if (srtobject->listener_poll_id == SRT_ERROR) {
+    srtobject->listener_poll_id = srt_epoll_create ();
+  }
 
   srtobject->opened =
       gst_srt_object_open_connection

--- a/ext/srt/gstsrtobject.c
+++ b/ext/srt/gstsrtobject.c
@@ -1053,6 +1053,7 @@ gst_srt_object_close (GstSRTObject * srtobject)
   if (srtobject->listener_poll_id != SRT_ERROR) {
     srt_epoll_remove_usock (srtobject->listener_poll_id,
         srtobject->listener_sock);
+    srt_epoll_release (srtobject->listener_poll_id);
     srtobject->listener_poll_id = SRT_ERROR;
   }
   if (srtobject->thread) {


### PR DESCRIPTION
This patch tries to fix an issues caused when there is no srt streaming,
which triggers a error "Invalid SRT socket. Trying to reconnect".
Under this situation e_poll is not released and eventually causes
an error like "Too many open files".