### PR TITLE
x265enc: fix deadlock on reconfig

### DIFF
--- a/ext/srt/gstsrtobject.c
+++ b/ext/srt/gstsrtobject.c
@@ -119,7 +119,7 @@ static struct srt_constant_params srt_params[] = {
   {"SRTO_SNDSYN", SRTO_SNDSYN, 0},      /* 0: non-blocking */
   {"SRTO_RCVSYN", SRTO_RCVSYN, 0},      /* 0: non-blocking */
   {"SRTO_LINGER", SRTO_LINGER, 0},
-  {"SRTO_TSBPMODE", SRTO_TSBPDMODE, 1}, /* Timestamp-based Packet Delivery mode must be enabled */
+  {"SRTO_TSBPDMODE", SRTO_TSBPDMODE, 1},        /* Timestamp-based Packet Delivery mode must be enabled */
   {NULL, -1, -1},
 };
 


### PR DESCRIPTION
Don't attempt to obtain encoder lock which is already held by gst_x265_enc_encode_frame().

